### PR TITLE
softer brackets match colors

### DIFF
--- a/themes/soft-era-color-theme.json
+++ b/themes/soft-era-color-theme.json
@@ -296,8 +296,8 @@ cute pairs:
     "editor.selectionBackground": "#eceafa",
     "editor.selectionForeground": "#958ac5",
     "editor.inactiveSelectionBackground": "#e2e1dfaa",
-    "editorBracketMatch.background": "#4a4543",
-    "editorBracketMatch.border": "#4a4543",
+    "editorBracketMatch.background": "#e4bcbf33",
+    "editorBracketMatch.border": "#e4bcbf33",
     "editorError.foreground": "#dd698ccc", // soft-red
     "editorInfo.foreground": "#82b4e3",
     "editorHint.foreground": "#98c4ba", // soft-yellow-darker


### PR DESCRIPTION
hi there! 

here is a suggestion for softer colors on bracket matches. You see those only if you have `"editor.matchBrackets": true` in your settings.