### PR TITLE
lighter terminal.ansiBrightBlack

### DIFF
--- a/themes/soft-era-color-theme.json
+++ b/themes/soft-era-color-theme.json
@@ -441,7 +441,7 @@ cute pairs:
     "terminal.ansiMagenta": "#be88d9",
     "terminal.ansiCyan": "#958ac5",
     "terminal.ansiWhite": "#f1ecee",
-    "terminal.ansiBrightBlack": "#6f5573",
+    "terminal.ansiBrightBlack": "#e7cecd",
     "terminal.ansiBrightRed": "#eeaabe",
     "terminal.ansiBrightGreen": "#98c4ba",
     "terminal.ansiBrightYellow": "#e7d59a",


### PR DESCRIPTION
I know `terminal.ansiBrightBlack` (fg=8) is the default color for [auto-suggestions under zsh](https://github.com/zsh-users/zsh-autosuggestions#suggestion-highlight-style). 

In that case, it would make sense to have it set for a very low contrast. See screenshot, I typed `git clone` and the git url is auto-suggested.

![screen shot 2019-01-30 at 11 16 49 pm](https://user-images.githubusercontent.com/116375/52030390-a8d2aa80-24e5-11e9-8c4d-0ba933a90e78.jpg)
