### PR TITLE
fix missing foreground color from tmtheme

### DIFF
--- a/themes/soft-era-test-1.tmTheme
+++ b/themes/soft-era-test-1.tmTheme
@@ -43,7 +43,7 @@
 				<key>caret</key>
 				<string>#eeaabe</string>
 				<key>foreground</key>
-				<string>#  </string>
+				<string>#c29ba3</string>
 				<key>invisibles</key>
 				<string>#d6d5d4</string>
 				<key>lineHighlight</key>


### PR DESCRIPTION
The missing foreground color was causing the default text of most syntaxes to appear red (#FF0000) on the latest VSCode version (1.41)

Feel free to close if this is not a real issue. Maybe it's just my setup that is wrong.